### PR TITLE
maintenance: h5py.default_file_mode is deprecated

### DIFF
--- a/qiita_files/util.py
+++ b/qiita_files/util.py
@@ -11,9 +11,13 @@ from contextlib import contextmanager
 import h5py
 
 
-# not present in all 2.x series
-if hasattr(h5py.get_config(), 'default_file_mode'):
-    h5py.get_config().default_file_mode = 'r'
+# deprecated sind h5py 3.3,
+# see https://docs.h5py.org/en/stable/whatsnew/3.6.html
+h5py_version = list(map(int, h5py.__version__.split('.')))
+if h5py_version < [3, 3, 0]:
+    # not present in all 2.x series
+    if hasattr(h5py.get_config(), 'default_file_mode'):
+        h5py.get_config().default_file_mode = 'r'
 
 
 def _is_string_or_bytes(s):

--- a/qiita_files/util.py
+++ b/qiita_files/util.py
@@ -7,13 +7,17 @@
 # -----------------------------------------------------------------------------
 
 from contextlib import contextmanager
+from packaging import version
 
 import h5py
 
 
-# not present in all 2.x series
-if hasattr(h5py.get_config(), 'default_file_mode'):
-    h5py.get_config().default_file_mode = 'r'
+# Setting h5py.default_file_mode is deprecated.
+# 'r' (read-only) is the default from h5py 3.0.
+if version.Version(h5py.__version__) <= version.Version("3.0"):
+    # not present in all 2.x series
+    if hasattr(h5py.get_config(), 'default_file_mode'):
+        h5py.get_config().default_file_mode = 'r'
 
 
 def _is_string_or_bytes(s):

--- a/qiita_files/util.py
+++ b/qiita_files/util.py
@@ -7,17 +7,8 @@
 # -----------------------------------------------------------------------------
 
 from contextlib import contextmanager
-from packaging import version
 
 import h5py
-
-
-# Setting h5py.default_file_mode is deprecated.
-# 'r' (read-only) is the default from h5py 3.0.
-if version.Version(h5py.__version__) <= version.Version("3.0"):
-    # not present in all 2.x series
-    if hasattr(h5py.get_config(), 'default_file_mode'):
-        h5py.get_config().default_file_mode = 'r'
 
 
 def _is_string_or_bytes(s):

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(name='qiita-files',
                 'qiita_files/format',
                 'qiita_files/parse'],
       extras_require={'test': ["nose >= 0.10.1", "pep8"]},
-      install_requires=['numpy', 'h5py', 'joblib', 'packaging'],
+      install_requires=['numpy', 'h5py', 'joblib'],
       classifiers=classifiers
       )

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setup(name='qiita-files',
                 'qiita_files/format',
                 'qiita_files/parse'],
       extras_require={'test': ["nose >= 0.10.1", "pep8"]},
-      install_requires=['numpy', 'h5py', 'joblib'],
+      install_requires=['numpy', 'h5py', 'joblib', 'packaging'],
       classifiers=classifiers
       )


### PR DESCRIPTION
When starting Qiita, the log reports about a deprecated use of `h5py.get_config().default_file_mode = 'r'`. This function was indeed deprecated with version 3.0.0. I therefore use the `packaging` lib to check if the used h5py version is older than that before trying to manually set to 'r'.

Should you feel we anyways would not use older h5py versions, we can delete these lines 15-20 in `qiita_files/util.py` altogether