### PR TITLE
Migrate to py310

### DIFF
--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
           matrix:
-            python-version: ["3.5, "3.6", "3.9", "3.10", "3.11", "3.12"]
+            python-version: ["3.5", "3.6", "3.9", "3.10", "3.11", "3.12"]
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -29,13 +29,13 @@ jobs:
           conda create --yes -n qiita-files python=${{ matrix.python-version }} h5py pandas scipy numpy
           conda activate qiita-files
           pip install .
-          pip install sphinx sphinx-bootstrap-theme nose-timer codecov Click
+          pip install sphinx sphinx-bootstrap-theme pytest-cov codecov Click
 
       - name: Main tests
         shell: bash -l {0}
         run: |
           conda activate qiita-files
-          nosetests --with-doctest --with-coverage --cover-package=qiita_files
+          pytest --with-doctest --cov=qiita_files --cov-report=lcov
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -35,7 +35,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate qiita-files
-          pytest --with-doctest --cov=qiita_files --cov-report=lcov
+          pytest --doctest-modules --cov=qiita_files --cov-report=lcov
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
           matrix:
-            python-version: ["3.5", "3.6", "3.9", "3.10", "3.11", "3.12"]
+            python-version: ["3.6", "3.9", "3.10", "3.11", "3.12"]
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
           matrix:
-            python-version: ["3.9", "3.10", "3.11", "3.12"]
+            python-version: ["3.5, "3.6", "3.9", "3.10", "3.11", "3.12"]
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -9,7 +9,9 @@ jobs:
   # derived from https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml
   main:
     runs-on: ubuntu-latest
-
+    strategy:
+          matrix:
+            python-version: ["3.9", "3.10"]
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code
@@ -19,12 +21,12 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
 
       - name: Basic dependencies install
         shell: bash -l {0}
         run: |
-          conda create --yes -n qiita-files python=3.9 h5py pandas scipy numpy
+          conda create --yes -n qiita-files python=${{ matrix.python-version }} h5py pandas scipy numpy
           conda activate qiita-files
           pip install .
           pip install sphinx sphinx-bootstrap-theme nose-timer codecov Click

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
           matrix:
-            python-version: ["3.6", "3.9", "3.10", "3.11", "3.12"]
+            python-version: ["3.5", "3.6", "3.9", "3.10", "3.11", "3.12"]
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code
@@ -35,7 +35,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda activate qiita-files
-          pytest --doctest-modules --cov=qiita_files --cov-report=lcov
+          pytest --doctest-modules --cov=qiita_files `if (( $(echo "${{ matrix.python-version }} > 3.6" | bc -l) )); then echo "--cov-report=lcov"; else echo ""; fi`
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/qiita-plugin-ci.yml
+++ b/.github/workflows/qiita-plugin-ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
           matrix:
-            python-version: ["3.9", "3.10"]
+            python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Check out repository code

--- a/qiita_files/parse/workflow.py
+++ b/qiita_files/parse/workflow.py
@@ -9,7 +9,10 @@ import sys
 from copy import deepcopy
 from time import time
 from functools import update_wrapper
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from types import MethodType
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ classes = """
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Operating System :: POSIX :: Linux
     Operating System :: MacOS :: MacOS X

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,8 @@ classes = """
     Programming Language :: Python
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Operating System :: POSIX :: Linux
     Operating System :: MacOS :: MacOS X


### PR DESCRIPTION
I found qiime2 to be a heavy dependency in e.g. qtp-biom. With "heavy", I refer to filesize or more precise image size, when putting the plugin into a container.

I therefore experiment with the new q2-tiny release to keep depending files smaller. This requires py3.10 - which is not yet supported by qiita-files.

This PR shall make qiita-files upwards compatible with py 3.10 - and adds according tests for py3.9 (current state) AND py3.10. With that, I also replace the deprecated nose with pytest for the github action.